### PR TITLE
Correct the 1.10.0 note and harden the release version guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,20 @@ jobs:
             10.0.x
 
       - name: Check the tag matches the project version
-        # A tag of v1.10 against a project version of 1.0.0 is how 1.10.0 ended up
-        # published as 1.10. Catch the mismatch here rather than on nuget.org.
+        # The tag drove the package version while <Version> said something else
+        # entirely, so the two could disagree without anything noticing. This is the
+        # only thing standing between a wrong tag and an irreversible push to NuGet,
+        # so it uses sed rather than grep -P: PCRE support depends on the locale, and
+        # a guard that fails to run on some runners is not a guard.
         run: |
           set -euo pipefail
           tag="${GITHUB_REF#refs/tags/v}"
-          project=$(grep -oPm1 '(?<=<Version>)[^<]+' DLeader.Consul/DLeader.Consul.csproj)
+          project=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' DLeader.Consul/DLeader.Consul.csproj | head -1)
           echo "tag=$tag project=$project"
+          if [ -z "$project" ]; then
+            echo "::error::Could not read <Version> from DLeader.Consul/DLeader.Consul.csproj"
+            exit 1
+          fi
           if [ "$tag" != "$project" ]; then
             echo "::error::Tag v$tag does not match <Version>$project</Version> in DLeader.Consul.csproj"
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ API that can be used correctly, and the one that could not is marked obsolete.
   are enabled repo-wide. The build went from 69 warnings to zero.
 - CI now runs on every push and pull request, not only on release tags, and publishing
   to NuGet is gated on those runs passing. The tag is checked against the project
-  version before publishing.
+  version before publishing, so a tag that disagrees with `<Version>` fails the release
+  rather than shipping a surprise.
 - The sample application uses the lease API throughout.
 
 ### Deprecated
@@ -139,9 +140,10 @@ API that can be used correctly, and the one that could not is marked obsolete.
 
 ## [1.10.0] - 2025-02
 
-Earlier releases are not documented here. `1.10.0` was published to NuGet as `1.10`
-because the release tag was `v1.10` and the workflow derived the package version from
-the tag; the project file still said `1.0.0`. Both are corrected in 1.11.0.
+Earlier releases are not documented here. The release tag was `v1.10` and the workflow
+derived the package version from it, which NuGet normalised to `1.10.0` — so the
+published version is correct. The project file, however, still said `1.0.0`, which is
+fixed in 1.11.0 along with a CI check that the tag and `<Version>` agree.
 
 [Unreleased]: https://github.com/FrancoPachue/dleader-consul/compare/v1.11.0...HEAD
 [1.11.0]: https://github.com/FrancoPachue/dleader-consul/compare/v1.10...v1.11.0


### PR DESCRIPTION
Two corrections before 1.11.0 ships.

**The changelog was wrong about 1.10.0.** It claimed the package was published as `1.10`. NuGet normalises a two-part version, so the tag `v1.10` produced a package the registry lists as `1.10.0` — which is correct. Verified against the registration index:

```
"version":"1.10.0"
```

The real defect was narrower: the project file said `1.0.0` while the tag drove the package version, so the two could disagree and nothing checked.

**The guard that now checks them was fragile.** It used `grep -oP`, and PCRE support in grep depends on the locale — it fails outright under some with `grep: -P supports only unibyte and UTF-8 locales`. That guard is the only thing between a wrong tag and an irreversible push to NuGet, so it now uses `sed`, and fails explicitly if it cannot read a version at all rather than comparing against an empty string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tsDNeid9iaigG6GP5izhz