### PR TITLE
Telemetry, migration guide, and real-cluster tests (1.13.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,22 @@ jobs:
           dotnet test DLeader.Consul.IntegrationTests/DLeader.Consul.IntegrationTests.csproj
           --configuration Release
           --no-build
+          --filter "Category!=Cluster"
           --logger "trx;LogFileName=integration.trx"
+          --results-directory artifacts/test-results
+
+      - name: Cluster failure tests (three-server Consul, real Raft)
+        # Run once rather than per target framework. These bring up three Consul servers
+        # and wait out real Raft elections, and what they exercise is the library's
+        # interaction with a quorum - nothing about them varies by target framework, so
+        # running them three times would triple the slowest step for no added signal.
+        run: >
+          dotnet test DLeader.Consul.IntegrationTests/DLeader.Consul.IntegrationTests.csproj
+          --configuration Release
+          --no-build
+          --framework net8.0
+          --filter "Category=Cluster"
+          --logger "trx;LogFileName=cluster.trx"
           --results-directory artifacts/test-results
 
       - name: Coverage summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-09-04
+
+Answers the question this library could not answer before: *why* did leadership move.
+
+### Added
+
+- **Telemetry.** An `ActivitySource` and a `Meter`, both named `DLeader.Consul`, wired
+  up through `LeadershipTelemetry.ActivitySourceName` / `.MeterName`.
+
+  The instrument that matters is `dleader.consul.leadership.lost` and its `reason` tag.
+  A leader that stood down because Consul expired its session
+  (`session_expired`, `lock_key_taken`) is a different incident from one that stood down
+  because it could not reach Consul and gave up on its own clock
+  (`local_deadline_exceeded`) — the second is what a network partition looks like from
+  inside the process. Until now the two were distinguishable only by reading log prose.
+
+  Also published: acquisitions by outcome, leases currently held, term duration, session
+  renewals by outcome, and fencing tokens issued. The last is worth an alert on
+  *decrease*: a token going backwards means the assumption fencing rests on has been
+  violated, which in practice means the Consul cluster was restored from a snapshot.
+
+- `ILeadershipLease.LostReason` exposes the same reason in code, for callers that want
+  to react differently to a partition than to an orderly hand-off. Added as a default
+  interface member, so existing implementations keep compiling.
+- **[MIGRATION.md](MIGRATION.md)** — moving from `IsLeaderAsync` to leases, step by
+  step, including the step people skip: making the target resource compare the fencing
+  token.
+- **Cluster failure tests.** A three-server Consul cluster with real Raft, exercising
+  quorum loss, Raft leader failover, and recovery. Every previous test ran against
+  `consul agent -dev`: a single node with no quorum to lose. The README claims the
+  leadership guarantees are Consul's, inherited — that claim was untested until now.
+
+### Deprecated
+
+- `IMessageBroker` is `[Obsolete]`. It moves to a separate `DLeader.Consul.Messaging`
+  package in 2.0. It has nothing to do with leader election, and shipping a non-durable
+  KV-backed fan-out inside a package that promises leadership guarantees invites it to
+  be mistaken for a queue. Nothing changes until 2.0.
+
+### Notes
+
+`ILeaderElection` will be removed **entirely** in 2.0 — not just `IsLeaderAsync` — along
+with the Consul service registration that only it used. Two APIs contending for the same
+lock key with different guarantees is the opposite of what the last three releases were
+for. See [MIGRATION.md](MIGRATION.md).
+
 ## [1.12.0] - 2026-09-04
 
 Closes the gaps opened as issues alongside 1.11.0.
@@ -208,7 +254,8 @@ derived the package version from it, which NuGet normalised to `1.10.0` — so t
 published version is correct. The project file, however, still said `1.0.0`, which is
 fixed in 1.11.0 along with a CI check that the tag and `<Version>` agree.
 
-[Unreleased]: https://github.com/FrancoPachue/dleader-consul/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/FrancoPachue/dleader-consul/compare/v1.13.0...HEAD
+[1.13.0]: https://github.com/FrancoPachue/dleader-consul/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/FrancoPachue/dleader-consul/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/FrancoPachue/dleader-consul/compare/v1.10...v1.11.0
 [1.10.0]: https://github.com/FrancoPachue/dleader-consul/releases/tag/v1.10

--- a/DLeader.Consul.Example/ExampleServices/DistributedCacheService.cs
+++ b/DLeader.Consul.Example/ExampleServices/DistributedCacheService.cs
@@ -1,3 +1,6 @@
+// IMessageBroker esta deprecado y se muda a su propio paquete en 2.0. El sample
+// lo sigue demostrando a proposito mientras siga formando parte de este paquete.
+#pragma warning disable CS0618
 ﻿using DLeader.Consul.Abstractions;
 using System.Collections.Concurrent;
 using System.Text.Json;

--- a/DLeader.Consul.Example/ExampleServices/QueueProcessorService.cs
+++ b/DLeader.Consul.Example/ExampleServices/QueueProcessorService.cs
@@ -1,3 +1,6 @@
+// IMessageBroker esta deprecado y se muda a su propio paquete en 2.0. El sample
+// lo sigue demostrando a proposito mientras siga formando parte de este paquete.
+#pragma warning disable CS0618
 ﻿using DLeader.Consul.Abstractions;
 using System.Collections.Concurrent;
 using System.Text.Json;

--- a/DLeader.Consul.Example/ExampleServices/ScheduledTasksService.cs
+++ b/DLeader.Consul.Example/ExampleServices/ScheduledTasksService.cs
@@ -1,3 +1,6 @@
+// IMessageBroker esta deprecado y se muda a su propio paquete en 2.0. El sample
+// lo sigue demostrando a proposito mientras siga formando parte de este paquete.
+#pragma warning disable CS0618
 ﻿using DLeader.Consul.Abstractions;
 using Consul;
 using System.Text.Json;

--- a/DLeader.Consul.Example/ExampleServices/WorkerService.cs
+++ b/DLeader.Consul.Example/ExampleServices/WorkerService.cs
@@ -1,3 +1,6 @@
+// IMessageBroker esta deprecado y se muda a su propio paquete en 2.0. El sample
+// lo sigue demostrando a proposito mientras siga formando parte de este paquete.
+#pragma warning disable CS0618
 ﻿using DLeader.Consul.Abstractions;
 
 namespace DLeader.Consul.Example.Services

--- a/DLeader.Consul.IntegrationTests/ClusterFailureTests.cs
+++ b/DLeader.Consul.IntegrationTests/ClusterFailureTests.cs
@@ -1,0 +1,218 @@
+using DLeader.Consul.Abstractions;
+using DLeader.Consul.Exceptions;
+
+namespace DLeader.Consul.IntegrationTests;
+
+/// <summary>
+/// The library against a real three-server Consul cluster, losing quorum and losing its
+/// Raft leader.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The README states that every leadership guarantee here is Consul's, inherited, and
+/// that the library adds no consensus of its own. That claim was previously untested:
+/// the rest of the suite runs against a single dev agent, which has no Raft to lose.
+/// These tests exercise the layer the guarantees actually rest on.
+/// </para>
+/// <para>
+/// They are slower than the rest of the suite by design — bootstrapping Raft and waiting
+/// out an election takes real time, and neither can be faked.
+/// </para>
+/// </remarks>
+// Each test in this class brings up its own three-server cluster, so letting them run
+// in parallel would mean a dozen Consul containers at once and elections competing for
+// the same CPU. One collection makes them sequential.
+[Collection("cluster")]
+[Trait("Category", "Cluster")]
+public class ClusterFailureTests : IAsyncLifetime
+{
+    private readonly ConsulCluster _cluster = new();
+
+    public Task InitializeAsync() => _cluster.InitializeAsync();
+
+    public Task DisposeAsync() => _cluster.DisposeAsync();
+
+    [Fact]
+    public async Task WithQuorum_LeadershipBehavesNormally()
+    {
+        var serviceName = ConsulCluster.NewServiceName();
+
+        await using var nodeA = _cluster.CreateNode(serviceName, servicePort: 5001, serverIndex: 0);
+        await using var nodeB = _cluster.CreateNode(serviceName, servicePort: 5002, serverIndex: 1);
+
+        // Two library instances talking to two different Consul servers, which is the
+        // arrangement a real deployment has and the single-agent suite cannot represent.
+        var attempts = await Task.WhenAll(
+            nodeA.TryAcquireLeadershipAsync(),
+            nodeB.TryAcquireLeadershipAsync());
+
+        var winners = attempts.Where(l => l is not null).ToArray();
+        Assert.Single(winners);
+
+        await winners[0]!.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task LosingQuorum_StopsGrantingLeases_AndTheHeldLeaseGivesUp()
+    {
+        var serviceName = ConsulCluster.NewServiceName();
+
+        await using var holder = _cluster.CreateNode(
+            serviceName, servicePort: 5001, serverIndex: 0, sessionTtlSeconds: 10, safetyMarginSeconds: 2);
+
+        var lease = await holder.TryAcquireLeadershipAsync();
+        Assert.NotNull(lease);
+
+        // Two of three servers down: the survivor cannot form a quorum, so Consul stops
+        // accepting writes. This is the failure the README calls "availability is lost;
+        // safety is not".
+        await _cluster.StopServerAsync(1);
+        await _cluster.StopServerAsync(2);
+
+        await WaitUntilAsync(
+            async () => (await _cluster.GetLeaderAsync()).Length == 0,
+            TimeSpan.FromSeconds(60),
+            "the cluster still reported a Raft leader after losing quorum");
+
+        // No new leases while there is no quorum.
+        await using var challenger = _cluster.CreateNode(
+            serviceName, servicePort: 5002, serverIndex: 0, sessionTtlSeconds: 10, safetyMarginSeconds: 2);
+
+        var refused = false;
+        try
+        {
+            refused = await challenger.TryAcquireLeadershipAsync() is null;
+        }
+        catch (LeadershipException)
+        {
+            // Consul refusing the write outright is an equally correct answer.
+            refused = true;
+        }
+
+        Assert.True(refused, "a lease was granted while the cluster had no quorum");
+
+        // And the existing holder stands down on its own local deadline, because its
+        // renewals cannot be committed either. Safety is preserved by nobody leading,
+        // not by the old leader carrying on.
+        await WaitUntilAsync(
+            () => Task.FromResult(lease!.LostToken.IsCancellationRequested),
+            TimeSpan.FromSeconds(60),
+            "the holder never gave up leadership after quorum was lost");
+
+        Assert.Equal(LeadershipLostReason.LocalDeadlineExceeded, lease!.LostReason);
+
+        await lease.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task LosingTheRaftLeader_KeepsFencingTokensMonotonic()
+    {
+        var serviceName = ConsulCluster.NewServiceName();
+
+        // Point the library at a server that is not the Raft leader, so stopping the
+        // leader exercises Consul's internal failover rather than just killing our own
+        // connection.
+        var raftLeader = await _cluster.GetLeaderIndexAsync();
+        Assert.InRange(raftLeader, 0, 2);
+
+        var survivor = Enumerable.Range(0, 3).First(i => i != raftLeader);
+
+        await using var before = _cluster.CreateNode(serviceName, servicePort: 5001, serverIndex: survivor);
+        var first = await before.TryAcquireLeadershipAsync();
+        Assert.NotNull(first);
+
+        var tokenBefore = first!.FencingToken;
+        await first.DisposeAsync();
+
+        // Kill the Raft leader. Two of three remain, so a quorum survives and the
+        // cluster elects a new one.
+        //
+        // Waiting for "some leader" is not enough: the survivors keep reporting the dead
+        // node's address until the election actually completes. Waiting for a leader
+        // that is not the one we killed is the condition that means the failover
+        // happened.
+        await _cluster.StopServerAsync(raftLeader);
+        var newLeader = await _cluster.WaitForNewLeaderAsync(raftLeader, TimeSpan.FromSeconds(90));
+
+        Assert.NotEqual(raftLeader, newLeader);
+
+        await using var after = _cluster.CreateNode(serviceName, servicePort: 5002, serverIndex: survivor);
+        var second = await AcquireWithRetriesAsync(after, TimeSpan.FromSeconds(60));
+        Assert.NotNull(second);
+
+        // The property everything downstream depends on: a Raft election inside Consul
+        // does not move indices backwards, so the fencing token still only grows. If
+        // this ever fails, resources fencing on the token would start rejecting the
+        // real leader.
+        Assert.True(
+            second!.FencingToken > tokenBefore,
+            $"fencing token went from {tokenBefore} to {second.FencingToken} across a Consul leader election");
+
+        await second.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task RegainingQuorum_RestoresLeadership()
+    {
+        var serviceName = ConsulCluster.NewServiceName();
+
+        await _cluster.StopServerAsync(2);
+        await _cluster.WaitForLeaderAsync(TimeSpan.FromSeconds(60));
+
+        // Two of three is still a quorum, so this should behave normally.
+        await using var node = _cluster.CreateNode(serviceName, servicePort: 5001, serverIndex: 0);
+        var lease = await AcquireWithRetriesAsync(node, TimeSpan.FromSeconds(60));
+
+        Assert.NotNull(lease);
+        Assert.False(lease!.LostToken.IsCancellationRequested);
+
+        await lease.DisposeAsync();
+
+        await _cluster.StartServerAsync(2);
+        await _cluster.WaitForLeaderAsync(TimeSpan.FromSeconds(60));
+    }
+
+    private static async Task<ILeadershipLease?> AcquireWithRetriesAsync(
+        ILeadershipLeaseProvider node, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                var lease = await node.TryAcquireLeadershipAsync();
+                if (lease is not null)
+                {
+                    return lease;
+                }
+            }
+            catch (LeadershipException)
+            {
+                // The cluster may still be settling after an election.
+            }
+
+            await Task.Delay(500);
+        }
+
+        return null;
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<Task<bool>> condition, TimeSpan timeout, string because)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition())
+            {
+                return;
+            }
+
+            await Task.Delay(500);
+        }
+
+        Assert.Fail(because);
+    }
+}

--- a/DLeader.Consul.IntegrationTests/ConsulCluster.cs
+++ b/DLeader.Consul.IntegrationTests/ConsulCluster.cs
@@ -1,0 +1,276 @@
+using Consul;
+using DLeader.Consul.Configuration;
+using DLeader.Consul.Implementations;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace DLeader.Consul.IntegrationTests;
+
+/// <summary>
+/// Three Consul servers with real Raft consensus.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every other test in this project runs against <c>consul agent -dev</c>: a single
+/// node, no quorum, no persistence. That verifies the library's own logic and found
+/// several real bugs, but it cannot exercise the thing the README's guarantees actually
+/// rest on — that Consul is strongly consistent. A single dev agent has no Raft to lose.
+/// </para>
+/// <para>
+/// This fixture is deliberately not shared with the rest of the suite: these tests stop
+/// and start servers, and a shared cluster would make them order-dependent.
+/// </para>
+/// </remarks>
+public sealed class ConsulCluster : IAsyncLifetime
+{
+    private const string Image = "hashicorp/consul:1.20";
+    private const int HttpPort = 8500;
+    private const int NodeCount = 3;
+
+    private INetwork _network = null!;
+    private readonly List<IContainer> _servers = new();
+
+    /// <summary>HTTP address of each server, indexed the same as <see cref="Nodes"/>.</summary>
+    public IReadOnlyList<string> Addresses { get; private set; } = Array.Empty<string>();
+
+    /// <summary>Node names, in the order they were started.</summary>
+    public IReadOnlyList<string> Nodes { get; private set; } = Array.Empty<string>();
+
+    public async Task InitializeAsync()
+    {
+        _network = new NetworkBuilder().Build();
+        await _network.CreateAsync();
+
+        var names = Enumerable.Range(0, NodeCount).Select(i => $"consul-{i}").ToArray();
+
+        // Every server retry-joins every other by network alias. Consul tolerates
+        // joining itself, so one list works for all three and there is no ordering
+        // requirement between them.
+        var joins = names.SelectMany(n => new[] { "-retry-join", n }).ToArray();
+
+        foreach (var name in names)
+        {
+            var container = new ContainerBuilder(Image)
+                .WithNetwork(_network)
+                .WithNetworkAliases(name)
+                .WithPortBinding(HttpPort, assignRandomHostPort: true)
+                .WithCommand(
+                    new[]
+                    {
+                        "agent", "-server",
+                        $"-bootstrap-expect={NodeCount}",
+                        "-client=0.0.0.0",
+                        $"-node={name}",
+                        "-data-dir=/consul/data"
+                    }.Concat(joins).ToArray())
+                .WithWaitStrategy(
+                    Wait.ForUnixContainer()
+                        .UntilHttpRequestIsSucceeded(r => r.ForPort(HttpPort).ForPath("/v1/status/leader")))
+                .Build();
+
+            await container.StartAsync();
+            _servers.Add(container);
+        }
+
+        Nodes = names;
+        Addresses = _servers
+            .Select(c => $"http://{c.Hostname}:{c.GetMappedPublicPort(HttpPort)}")
+            .ToList();
+
+        await WaitForLeaderAsync(TimeSpan.FromMinutes(2));
+    }
+
+    public async Task DisposeAsync()
+    {
+        foreach (var server in _servers)
+        {
+            try
+            {
+                await server.DisposeAsync();
+            }
+            catch
+            {
+                // Best effort; the network teardown below is what matters.
+            }
+        }
+
+        if (_network is not null)
+        {
+            await _network.DeleteAsync();
+        }
+    }
+
+    /// <summary>
+    /// Waits until some server reports a Raft leader. An empty string from
+    /// <c>/v1/status/leader</c> means the cluster has no leader right now, which is
+    /// exactly the state a quorum-loss test wants to observe.
+    /// </summary>
+    public async Task WaitForLeaderAsync(TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await GetLeaderAsync() is { Length: > 0 })
+            {
+                return;
+            }
+
+            await Task.Delay(500);
+        }
+
+        throw new TimeoutException($"The cluster elected no Raft leader within {timeout}.");
+    }
+
+    /// <summary>The Raft leader's address, or empty when the cluster has none.</summary>
+    public async Task<string> GetLeaderAsync()
+    {
+        foreach (var index in Enumerable.Range(0, _servers.Count).Where(IsRunning))
+        {
+            try
+            {
+                using var client = CreateClient(index);
+                var leader = await client.Status.Leader();
+
+                if (!string.IsNullOrWhiteSpace(leader))
+                {
+                    return leader;
+                }
+            }
+            catch
+            {
+                // This server may be the one that is down. Ask the next.
+            }
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>Index of the server currently acting as Raft leader, or -1.</summary>
+    /// <remarks>
+    /// <c>Status.Leader</c> returns <c>ip:raft-port</c> on the container network, which
+    /// is not a host address and cannot be matched against the mapped ports. The
+    /// catalog maps that address back to a node name, and the node names are ours
+    /// (<c>consul-0</c>..<c>consul-2</c>), so the name is what identifies the index.
+    /// </remarks>
+    public async Task<int> GetLeaderIndexAsync()
+    {
+        var leader = await GetLeaderAsync();
+        if (leader.Length == 0)
+        {
+            return -1;
+        }
+
+        var ip = leader.Split(':')[0];
+
+        foreach (var index in Enumerable.Range(0, _servers.Count).Where(IsRunning))
+        {
+            try
+            {
+                using var client = CreateClient(index);
+                var nodes = await client.Catalog.Nodes();
+
+                var match = nodes.Response?.FirstOrDefault(n => n.Address == ip);
+                if (match is null)
+                {
+                    continue;
+                }
+
+                var nodeIndex = Nodes.ToList().IndexOf(match.Name);
+                if (nodeIndex >= 0)
+                {
+                    return nodeIndex;
+                }
+            }
+            catch
+            {
+                // Skip unreachable servers.
+            }
+        }
+
+        return -1;
+    }
+
+    private bool IsRunning(int index) => _stopped.Contains(index) == false;
+
+    private readonly HashSet<int> _stopped = new();
+
+    /// <summary>
+    /// Waits until the cluster reports a Raft leader that is not
+    /// <paramref name="excluding"/>, and returns its index.
+    /// </summary>
+    /// <remarks>
+    /// Waiting only for a non-empty answer from <c>/v1/status/leader</c> is not enough
+    /// after stopping the leader: the survivors keep reporting the dead node's address
+    /// until the election completes, so a caller that stops the leader and immediately
+    /// asks who leads gets the node it just killed. Naming the node to exclude is what
+    /// makes this wait mean "the election finished".
+    /// </remarks>
+    public async Task<int> WaitForNewLeaderAsync(int excluding, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var index = await GetLeaderIndexAsync();
+            if (index >= 0 && index != excluding)
+            {
+                return index;
+            }
+
+            await Task.Delay(500);
+        }
+
+        throw new TimeoutException(
+            $"No server other than {Nodes[excluding]} became Raft leader within {timeout}.");
+    }
+
+    /// <summary>Stops one server, as a crash would.</summary>
+    public async Task StopServerAsync(int index)
+    {
+        await _servers[index].StopAsync();
+        _stopped.Add(index);
+    }
+
+    /// <summary>Brings a stopped server back.</summary>
+    public async Task StartServerAsync(int index)
+    {
+        await _servers[index].StartAsync();
+        _stopped.Remove(index);
+    }
+
+    public IConsulClient CreateClient(int index) =>
+        new ConsulClient(cfg => cfg.Address = new Uri(Addresses[index]));
+
+    /// <summary>An instance pointed at one specific server of the cluster.</summary>
+    public ConsulLeaderElection CreateNode(
+        string serviceName,
+        int servicePort,
+        int serverIndex = 0,
+        int sessionTtlSeconds = 10,
+        int lockDelaySeconds = 3,
+        int safetyMarginSeconds = 2)
+    {
+        var consulOptions = new ConsulOptions
+        {
+            ServiceName = serviceName,
+            Address = Addresses[serverIndex],
+            SessionTTL = sessionTtlSeconds,
+            LockDelaySeconds = lockDelaySeconds,
+            LeaseSafetyMarginSeconds = safetyMarginSeconds
+        };
+
+        return new ConsulLeaderElection(
+            NullLogger<ConsulLeaderElection>.Instance,
+            Options.Create(consulOptions),
+            Options.Create(new ServiceRegistrationOptions { ServicePort = servicePort }),
+            CreateClient(serverIndex));
+    }
+
+    public static string NewServiceName(
+        [System.Runtime.CompilerServices.CallerMemberName] string caller = "") =>
+        $"{caller.ToLowerInvariant()}-{Guid.NewGuid():N}";
+}

--- a/DLeader.Consul.IntegrationTests/TelemetryTests.cs
+++ b/DLeader.Consul.IntegrationTests/TelemetryTests.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics.Metrics;
+using DLeader.Consul.Abstractions;
+using DLeader.Consul.Diagnostics;
+
+namespace DLeader.Consul.IntegrationTests;
+
+/// <summary>
+/// That the metrics report the right reason, not just that they fire.
+/// </summary>
+/// <remarks>
+/// The value of the <c>reason</c> tag is the whole point of this instrumentation: a
+/// leader that stood down because Consul expired its session is a different incident
+/// from one that stood down because it could not reach Consul. A test that only checked
+/// "a loss was counted" would pass with the two swapped, and would have been worse than
+/// no test — it would have made a wrong dashboard look verified.
+/// </remarks>
+public class TelemetryTests
+{
+    /// <summary>Collects one instrument into a list, for the duration of the using block.</summary>
+    private sealed class Recorder : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+        private readonly List<(long Value, Dictionary<string, object?> Tags)> _measurements = new();
+        private readonly object _gate = new();
+
+        public Recorder(string instrumentName)
+        {
+            _listener.InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == LeadershipTelemetry.MeterName &&
+                    instrument.Name == instrumentName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+            {
+                var copy = new Dictionary<string, object?>();
+                foreach (var tag in tags)
+                {
+                    copy[tag.Key] = tag.Value;
+                }
+
+                lock (_gate)
+                {
+                    _measurements.Add((value, copy));
+                }
+            });
+
+            _listener.Start();
+        }
+
+        public IReadOnlyList<(long Value, Dictionary<string, object?> Tags)> Measurements
+        {
+            get { lock (_gate) { return _measurements.ToList(); } }
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    [Fact]
+    public async Task LosingTheSession_ReportsSessionExpired_NotTheLocalDeadline()
+    {
+        var consul = new ConsulContainer();
+        await consul.InitializeAsync();
+
+        try
+        {
+            using var losses = new Recorder("dleader.consul.leadership.lost");
+
+            var serviceName = ConsulContainer.NewServiceName();
+            await using var node = consul.CreateNode(serviceName, servicePort: 5001);
+
+            var lease = await node.TryAcquireLeadershipAsync();
+            Assert.NotNull(lease);
+
+            // Consul is up and reachable; it simply decides the session is gone.
+            using (var client = consul.CreateClient())
+            {
+                var sessions = await client.Session.List();
+                var target = sessions.Response.Single(s => s.Name == node.InstanceId);
+                await client.Session.Destroy(target.ID);
+            }
+
+            await WaitUntilAsync(
+                () => lease!.LostToken.IsCancellationRequested,
+                TimeSpan.FromSeconds(30),
+                "the lease never noticed the session was destroyed");
+
+            // Consul told us, so it must not be attributed to the local deadline.
+            Assert.Equal(LeadershipLostReason.LockKeyTaken, lease!.LostReason);
+
+            var reasons = losses.Measurements
+                .Where(m => Equals(m.Tags.GetValueOrDefault("service"), serviceName))
+                .Select(m => m.Tags.GetValueOrDefault("reason") as string)
+                .ToList();
+
+            Assert.Contains("lock_key_taken", reasons);
+            Assert.DoesNotContain("local_deadline_exceeded", reasons);
+
+            await lease.DisposeAsync();
+        }
+        finally
+        {
+            await consul.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ConsulBecomingUnreachable_ReportsTheLocalDeadline_NotSessionExpired()
+    {
+        var consul = new ConsulContainer();
+        await consul.InitializeAsync();
+
+        try
+        {
+            using var losses = new Recorder("dleader.consul.leadership.lost");
+
+            var serviceName = ConsulContainer.NewServiceName();
+            await using var node = consul.CreateNode(
+                serviceName, servicePort: 5001, sessionTtlSeconds: 10, safetyMarginSeconds: 2);
+
+            var lease = await node.TryAcquireLeadershipAsync();
+            Assert.NotNull(lease);
+
+            // Nobody tells us anything: the agent is simply gone.
+            await consul.StopAgentAsync();
+
+            await WaitUntilAsync(
+                () => lease!.LostToken.IsCancellationRequested,
+                TimeSpan.FromSeconds(45),
+                "the lease never gave up after Consul became unreachable");
+
+            // This is the distinction that matters: the node decided, not Consul.
+            Assert.Equal(LeadershipLostReason.LocalDeadlineExceeded, lease!.LostReason);
+
+            var reasons = losses.Measurements
+                .Where(m => Equals(m.Tags.GetValueOrDefault("service"), serviceName))
+                .Select(m => m.Tags.GetValueOrDefault("reason") as string)
+                .ToList();
+
+            Assert.Contains("local_deadline_exceeded", reasons);
+            Assert.DoesNotContain("session_expired", reasons);
+        }
+        finally
+        {
+            await consul.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task DisposingCleanly_ReportsReleased_AndBalancesTheHeldGauge()
+    {
+        var consul = new ConsulContainer();
+        await consul.InitializeAsync();
+
+        try
+        {
+            using var held = new Recorder("dleader.consul.leadership.held");
+
+            var serviceName = ConsulContainer.NewServiceName();
+            await using var node = consul.CreateNode(serviceName, servicePort: 5001);
+
+            var lease = await node.TryAcquireLeadershipAsync();
+            Assert.NotNull(lease);
+            await lease!.DisposeAsync();
+
+            Assert.Equal(LeadershipLostReason.Released, lease.LostReason);
+
+            // A gauge that only ever increments is how you end up with a dashboard
+            // claiming six leaders for a service that has one.
+            var net = held.Measurements
+                .Where(m => Equals(m.Tags.GetValueOrDefault("service"), serviceName))
+                .Sum(m => m.Value);
+
+            Assert.Equal(0, net);
+        }
+        finally
+        {
+            await consul.DisposeAsync();
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout, string because)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(200);
+        }
+
+        Assert.Fail(because);
+    }
+}

--- a/DLeader.Consul.Tests/ServiceCollectionExtensionsTests.cs
+++ b/DLeader.Consul.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,3 +1,6 @@
+// Estos tests cubren a proposito el registro de IMessageBroker, que sigue
+// existiendo hasta que 2.0 lo mude a su propio paquete.
+#pragma warning disable CS0618
 ﻿using Xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/DLeader.Consul/Abstractions/ILeadershipLease.cs
+++ b/DLeader.Consul/Abstractions/ILeadershipLease.cs
@@ -88,4 +88,24 @@ public interface ILeadershipLease : IAsyncDisposable
     /// </para>
     /// </remarks>
     long FencingToken { get; }
+
+    /// <summary>
+    /// Why the lease was lost, once <see cref="LostToken"/> has been cancelled.
+    /// <see langword="null"/> while the lease is still held.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The distinction worth acting on is between
+    /// <see cref="LeadershipLostReason.SessionExpired"/> and
+    /// <see cref="LeadershipLostReason.LocalDeadlineExceeded"/>. The first means Consul
+    /// decided this instance was gone. The second means this instance could not reach
+    /// Consul to be told anything and stood down on its own clock — which is what a
+    /// network partition looks like from in here.
+    /// </para>
+    /// <para>
+    /// The default implementation returns <see langword="null"/> so that adding this
+    /// member did not break existing implementations of the interface.
+    /// </para>
+    /// </remarks>
+    LeadershipLostReason? LostReason => null;
 }

--- a/DLeader.Consul/Abstractions/IMessageBroker.cs
+++ b/DLeader.Consul/Abstractions/IMessageBroker.cs
@@ -11,6 +11,12 @@ namespace DLeader.Consul.Abstractions;
 /// is published will never see it. Anything that must not be lost belongs in a real
 /// broker.
 /// </remarks>
+[Obsolete(
+    "IMessageBroker is moving to a separate DLeader.Consul.Messaging package in 2.0. " +
+    "It has nothing to do with leader election, and shipping a non-durable KV-backed " +
+    "fan-out inside a package that promises leadership guarantees invites it to be " +
+    "mistaken for a queue. Nothing changes for now; install the messaging package when " +
+    "2.0 ships, or move to a real broker if you need delivery guarantees.")]
 public interface IMessageBroker
 {
     /// <summary>

--- a/DLeader.Consul/Abstractions/LeadershipLostReason.cs
+++ b/DLeader.Consul/Abstractions/LeadershipLostReason.cs
@@ -1,0 +1,39 @@
+namespace DLeader.Consul.Abstractions;
+
+/// <summary>
+/// Why a lease stopped being held.
+/// </summary>
+/// <remarks>
+/// The distinction that matters operationally is between
+/// <see cref="SessionExpired"/> and <see cref="LocalDeadlineExceeded"/>. The first
+/// means Consul decided this node was gone and said so. The second means this node
+/// could not reach Consul to be told anything and stood down on its own clock. They
+/// look identical from the outside and point at completely different problems.
+/// </remarks>
+public enum LeadershipLostReason
+{
+    /// <summary>Consul reported the session as expired or invalid.</summary>
+    SessionExpired,
+
+    /// <summary>
+    /// No session renewal succeeded within <c>SessionTTL - LeaseSafetyMarginSeconds</c>,
+    /// measured on a monotonic local clock. Consul was unreachable, so this node gave up
+    /// on its own rather than waiting to be told.
+    /// </summary>
+    LocalDeadlineExceeded,
+
+    /// <summary>
+    /// A watch on the lock key observed it held by a different session, or gone.
+    /// </summary>
+    LockKeyTaken,
+
+    /// <summary>The lease was disposed by its owner. The ordinary path.</summary>
+    Released,
+
+    /// <summary>
+    /// The token passed to
+    /// <see cref="ILeadershipLeaseProvider.TryAcquireLeadershipAsync"/> was cancelled,
+    /// usually because the host is shutting down.
+    /// </summary>
+    Cancelled
+}

--- a/DLeader.Consul/DLeader.Consul.csproj
+++ b/DLeader.Consul/DLeader.Consul.csproj
@@ -5,10 +5,9 @@
 
     <!-- NuGet Package Information -->
     <PackageId>DLeader.Consul</PackageId>
-    <Version>1.12.0</Version>
+    <Version>1.13.0</Version>
     <Authors>FrancoPachue</Authors>
     <Description>Distributed leader election for .NET on HashiCorp Consul, with leases that carry a fencing token and signal loss of leadership through a cancellation token.</Description>
-    <PackageTags>consul;leader-election;distributed-systems;dotnet;microservices;distributed-lock;fencing-token</PackageTags>
     <PackageProjectUrl>https://github.com/FrancoPachue/dleader-consul</PackageProjectUrl>
     <RepositoryUrl>https://github.com/FrancoPachue/dleader-consul</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -16,6 +15,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReleaseNotes>See CHANGELOG.md</PackageReleaseNotes>
+    <PackageTags>consul;leader-election;distributed-systems;dotnet;microservices;distributed-lock;fencing-token;opentelemetry</PackageTags>
 
     <!-- Source Link -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -31,6 +31,9 @@
 
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\" />
+    <!-- Shipped in the package so the upgrade path travels with the thing being
+         upgraded, rather than living only in a repo the consumer may never open. -->
+    <None Include="$(MSBuildThisFileDirectory)..\MIGRATION.md" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)..\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/DLeader.Consul/Diagnostics/LeadershipTelemetry.cs
+++ b/DLeader.Consul/Diagnostics/LeadershipTelemetry.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace DLeader.Consul.Diagnostics;
+
+/// <summary>
+/// The names this library publishes telemetry under, and the instruments themselves.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Subscribe with OpenTelemetry using the public name constants:
+/// </para>
+/// <code>
+/// builder.Services.AddOpenTelemetry()
+///     .WithTracing(t => t.AddSource(LeadershipTelemetry.ActivitySourceName))
+///     .WithMetrics(m => m.AddMeter(LeadershipTelemetry.MeterName));
+/// </code>
+/// <para>
+/// The instrument that matters operationally is
+/// <c>dleader.consul.leadership.lost</c> and its <c>reason</c> tag. A leader that
+/// stands down because Consul expired its session is a different incident from one that
+/// stands down because its own local deadline passed: the first means Consul made a
+/// decision, the second means this node could not reach Consul to hear one. Logs
+/// carried that difference only in prose.
+/// </para>
+/// </remarks>
+public static class LeadershipTelemetry
+{
+    /// <summary>Name of the <see cref="System.Diagnostics.ActivitySource"/> this library publishes spans on.</summary>
+    public const string ActivitySourceName = "DLeader.Consul";
+
+    /// <summary>Name of the <see cref="System.Diagnostics.Metrics.Meter"/> this library publishes instruments on.</summary>
+    public const string MeterName = "DLeader.Consul";
+
+    /// <summary>Version reported for both the activity source and the meter.</summary>
+    public const string Version = "1.13.0";
+
+    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version);
+
+    private static readonly Meter Meter = new(MeterName, Version);
+
+    /// <summary>Acquisition attempts, tagged with the outcome.</summary>
+    internal static readonly Counter<long> Acquisitions = Meter.CreateCounter<long>(
+        "dleader.consul.leadership.acquisitions",
+        unit: "{attempt}",
+        description: "Leadership acquisition attempts, tagged by outcome (acquired, contended, failed).");
+
+    /// <summary>Leadership losses, tagged with which detector fired.</summary>
+    internal static readonly Counter<long> Losses = Meter.CreateCounter<long>(
+        "dleader.consul.leadership.lost",
+        unit: "{loss}",
+        description: "Leadership losses, tagged by reason. The reason distinguishes a decision Consul made from one this node made without reaching Consul.");
+
+    /// <summary>How long each leadership term lasted.</summary>
+    internal static readonly Histogram<double> Tenure = Meter.CreateHistogram<double>(
+        "dleader.consul.leadership.tenure",
+        unit: "s",
+        description: "Duration of each completed leadership term.");
+
+    /// <summary>1 while this process holds a lease, 0 otherwise.</summary>
+    internal static readonly UpDownCounter<long> Held = Meter.CreateUpDownCounter<long>(
+        "dleader.consul.leadership.held",
+        unit: "{lease}",
+        description: "Leases currently held by this process. Summed across a fleet it should never exceed one per service.");
+
+    /// <summary>Session renewal attempts, tagged with the outcome.</summary>
+    internal static readonly Counter<long> Renewals = Meter.CreateCounter<long>(
+        "dleader.consul.session.renewals",
+        unit: "{renewal}",
+        description: "Session renewal attempts, tagged by outcome (ok, failed, expired).");
+
+    /// <summary>
+    /// Fencing token of the most recent lease this process acquired, per service.
+    /// </summary>
+    /// <remarks>
+    /// Useful as a monotonicity check: this value going backwards for a service means
+    /// the assumption fencing rests on has been violated, which in practice means the
+    /// Consul cluster was restored from a snapshot or rebuilt.
+    /// </remarks>
+    internal static readonly Counter<long> FencingTokenIssued = Meter.CreateCounter<long>(
+        "dleader.consul.leadership.fencing_token_issued",
+        unit: "{token}",
+        description: "Fencing tokens issued to this process.");
+}

--- a/DLeader.Consul/Extensions/ServiceCollectionExtensions.cs
+++ b/DLeader.Consul/Extensions/ServiceCollectionExtensions.cs
@@ -63,7 +63,10 @@ namespace DLeader.Consul.Extensions
             // Messaging doesn't strictly need ServiceRegistrationOptions, but needs ConsulOptions
             AddConsulCore(services, configureConsul, null);
 
-            services.TryAddSingleton<IMessageBroker>(sp => 
+            // Registering a type this package deprecates, on purpose: it still ships and
+            // still works until 2.0 moves it to its own package.
+#pragma warning disable CS0618
+            services.TryAddSingleton<IMessageBroker>(sp =>
             {
                 var consulClient = sp.GetRequiredService<IConsulClient>();
                 var logger = sp.GetRequiredService<ILogger<ConsulMessageBroker>>();

--- a/DLeader.Consul/Implementations/ConsulLeaderElection.cs
+++ b/DLeader.Consul/Implementations/ConsulLeaderElection.cs
@@ -1,8 +1,10 @@
 using Consul;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using System.Text;
 using DLeader.Consul.Configuration;
 using DLeader.Consul.Abstractions;
+using DLeader.Consul.Diagnostics;
 using DLeader.Consul.Exceptions;
 using Microsoft.Extensions.Options;
 
@@ -133,6 +135,11 @@ public class ConsulLeaderElection :
 
         string? sessionId = null;
 
+        using var activity = LeadershipTelemetry.ActivitySource.StartActivity(
+            "TryAcquireLeadership", ActivityKind.Client);
+        activity?.SetTag("dleader.service", _options.ServiceName);
+        activity?.SetTag("dleader.instance_id", _instanceId);
+
         try
         {
             sessionId = await CreateLeaseSessionAsync(ttl, cancellationToken);
@@ -149,6 +156,9 @@ public class ConsulLeaderElection :
                 // Either someone else holds it, or Consul's lock delay from a previous
                 // holder's failure has not elapsed yet. Both are ordinary outcomes.
                 await DestroySessionQuietlyAsync(sessionId);
+
+                activity?.SetTag("dleader.outcome", "contended");
+                RecordAcquisition("contended");
                 return null;
             }
 
@@ -170,6 +180,9 @@ public class ConsulLeaderElection :
                     _lockKey, confirmation.Response?.Session ?? "nobody");
 
                 await DestroySessionQuietlyAsync(sessionId);
+
+                activity?.SetTag("dleader.outcome", "contended");
+                RecordAcquisition("contended");
                 return null;
             }
 
@@ -186,6 +199,7 @@ public class ConsulLeaderElection :
                 _lockKey,
                 _instanceId,
                 sessionId,
+                _options.ServiceName,
                 (long)modifyIndex,
                 modifyIndex,
                 ttl,
@@ -195,6 +209,20 @@ public class ConsulLeaderElection :
             _logger.LogInformation(
                 "Acquired leadership lease for {InstanceId} with fencing token {FencingToken}",
                 _instanceId, lease.FencingToken);
+
+            activity?.SetTag("dleader.outcome", "acquired");
+            activity?.SetTag("dleader.fencing_token", lease.FencingToken);
+
+            RecordAcquisition("acquired");
+
+            LeadershipTelemetry.Held.Add(1,
+                new KeyValuePair<string, object?>("service", _options.ServiceName));
+
+            // Emitted so a monitoring system can alert on the token going backwards,
+            // which would mean the Consul cluster was restored or rebuilt and the
+            // assumption fencing rests on no longer holds.
+            LeadershipTelemetry.FencingTokenIssued.Add(lease.FencingToken,
+                new KeyValuePair<string, object?>("service", _options.ServiceName));
 
             return lease;
         }
@@ -211,6 +239,10 @@ public class ConsulLeaderElection :
             }
 
             _logger.LogError(ex, "Error acquiring leadership lease for {InstanceId}", _instanceId);
+
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            RecordAcquisition("failed");
+
             throw new LeadershipException("Failed to acquire leadership lease", ex);
         }
     }
@@ -298,6 +330,11 @@ public class ConsulLeaderElection :
         var result = await _consulClient.Session.Create(sessionEntry, cancellationToken);
         return result.Response;
     }
+
+    private void RecordAcquisition(string outcome) =>
+        LeadershipTelemetry.Acquisitions.Add(1,
+            new KeyValuePair<string, object?>("service", _options.ServiceName),
+            new KeyValuePair<string, object?>("outcome", outcome));
 
     private async Task DestroySessionQuietlyAsync(string sessionId)
     {

--- a/DLeader.Consul/Implementations/ConsulLeadershipLease.cs
+++ b/DLeader.Consul/Implementations/ConsulLeadershipLease.cs
@@ -1,5 +1,6 @@
 using Consul;
 using DLeader.Consul.Abstractions;
+using DLeader.Consul.Diagnostics;
 using Microsoft.Extensions.Logging;
 using System.Text;
 
@@ -39,6 +40,18 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
     /// <summary>Monotonic timestamp of the last successful session renewal.</summary>
     private long _lastRenewalTicks;
 
+    /// <summary>Monotonic timestamp of acquisition, for the tenure histogram.</summary>
+    private readonly long _acquiredAtTicks = Environment.TickCount64;
+
+    /// <summary>
+    /// The loss reason, stored as the enum value plus one so that 0 means "still held".
+    /// An int because three loops race to set it and only the first should win.
+    /// </summary>
+    private int _lostReason;
+
+    /// <summary>Service name, carried purely as a metric tag.</summary>
+    private readonly string _serviceName;
+
     private Task? _renewalLoop;
     private Task? _watchdogLoop;
     private Task? _watchLoop;
@@ -50,12 +63,23 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
     /// <inheritdoc />
     public long FencingToken { get; }
 
+    /// <inheritdoc />
+    public LeadershipLostReason? LostReason
+    {
+        get
+        {
+            var stored = Volatile.Read(ref _lostReason);
+            return stored == 0 ? null : (LeadershipLostReason)(stored - 1);
+        }
+    }
+
     internal ConsulLeadershipLease(
         IConsulClient consulClient,
         ILogger logger,
         string lockKey,
         string instanceId,
         string sessionId,
+        string serviceName,
         long fencingToken,
         ulong acquiredAtIndex,
         TimeSpan ttl,
@@ -67,6 +91,7 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
         _lockKey = lockKey;
         _instanceId = instanceId;
         _sessionId = sessionId;
+        _serviceName = serviceName;
         _ttl = ttl;
         FencingToken = fencingToken;
 
@@ -111,6 +136,10 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
 
                 Interlocked.Exchange(ref _lastRenewalTicks, Environment.TickCount64);
                 delay = normalInterval;
+
+                LeadershipTelemetry.Renewals.Add(1,
+                    new KeyValuePair<string, object?>("service", _serviceName),
+                    new KeyValuePair<string, object?>("outcome", "ok"));
             }
             catch (OperationCanceledException)
             {
@@ -118,12 +147,12 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
             }
             catch (SessionExpiredException ex)
             {
-                MarkLost("Consul reports the session as expired: " + ex.Message);
+                MarkLost(LeadershipLostReason.SessionExpired, "Consul reports the session as expired: " + ex.Message);
                 break;
             }
             catch (ConsulRequestException ex) when (IsSessionGone(ex))
             {
-                MarkLost("Consul rejected the renewal as an invalid session: " + ex.Message);
+                MarkLost(LeadershipLostReason.SessionExpired, "Consul rejected the renewal as an invalid session: " + ex.Message);
                 break;
             }
             catch (Exception ex)
@@ -135,6 +164,12 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
                     "Session renewal failed for lease {SessionId} on {InstanceId}; retrying in {Delay}",
                     _sessionId, _instanceId, retryInterval);
                 delay = retryInterval;
+
+                // A rising failure count with no corresponding loss is the early warning
+                // that the margin is being eaten into.
+                LeadershipTelemetry.Renewals.Add(1,
+                    new KeyValuePair<string, object?>("service", _serviceName),
+                    new KeyValuePair<string, object?>("outcome", "failed"));
             }
         }
     }
@@ -165,6 +200,7 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
             if (sinceRenewal >= (long)_localDeadline.TotalMilliseconds)
             {
                 MarkLost(
+                    LeadershipLostReason.LocalDeadlineExceeded,
                     "no session renewal succeeded in " + sinceRenewal +
                     " ms, which exceeds the local deadline of " +
                     _localDeadline.TotalMilliseconds + " ms");
@@ -200,13 +236,14 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
 
                 if (result.Response is null)
                 {
-                    MarkLost("the lock key no longer exists");
+                    MarkLost(LeadershipLostReason.LockKeyTaken, "the lock key no longer exists");
                     break;
                 }
 
                 if (!string.Equals(result.Response.Session, _sessionId, StringComparison.Ordinal))
                 {
                     MarkLost(
+                        LeadershipLostReason.LockKeyTaken,
                         "the lock key is no longer held by this session (now held by " +
                         (result.Response.Session ?? "nobody") + ")");
                     break;
@@ -236,16 +273,30 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
         }
     }
 
-    private void MarkLost(string reason)
+    private void MarkLost(LeadershipLostReason reason, string detail)
     {
-        if (_lostCts.IsCancellationRequested)
+        // Only the first detector to fire owns the reason. Three loops race to call
+        // this, and the one that got there first is the one that actually decided.
+        if (Interlocked.CompareExchange(ref _lostReason, (int)reason + 1, 0) != 0)
         {
             return;
         }
 
         _logger.LogWarning(
-            "Leadership lease lost by {InstanceId} (fencing token {FencingToken}): {Reason}",
-            _instanceId, FencingToken, reason);
+            "Leadership lease lost by {InstanceId} (fencing token {FencingToken}, reason {Reason}): {Detail}",
+            _instanceId, FencingToken, reason, detail);
+
+        LeadershipTelemetry.Losses.Add(1,
+            new KeyValuePair<string, object?>("service", _serviceName),
+            new KeyValuePair<string, object?>("reason", ReasonTag(reason)));
+
+        LeadershipTelemetry.Held.Add(-1,
+            new KeyValuePair<string, object?>("service", _serviceName));
+
+        LeadershipTelemetry.Tenure.Record(
+            (Environment.TickCount64 - _acquiredAtTicks) / 1000.0,
+            new KeyValuePair<string, object?>("service", _serviceName),
+            new KeyValuePair<string, object?>("reason", ReasonTag(reason)));
 
         try
         {
@@ -256,6 +307,20 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
             // Raced with disposal; the lease is going away anyway.
         }
     }
+
+    /// <summary>
+    /// Stable, low-cardinality tag values. The enum names would work, but pinning them
+    /// here means renaming the enum cannot silently break someone's dashboard.
+    /// </summary>
+    private static string ReasonTag(LeadershipLostReason reason) => reason switch
+    {
+        LeadershipLostReason.SessionExpired => "session_expired",
+        LeadershipLostReason.LocalDeadlineExceeded => "local_deadline_exceeded",
+        LeadershipLostReason.LockKeyTaken => "lock_key_taken",
+        LeadershipLostReason.Released => "released",
+        LeadershipLostReason.Cancelled => "cancelled",
+        _ => "unknown"
+    };
 
     /// <summary>
     /// True when the exception is Consul rejecting an operation because the session no
@@ -274,6 +339,13 @@ internal sealed class ConsulLeadershipLease : ILeadershipLease
         {
             return;
         }
+
+        // Records the term and decrements the held gauge, unless a detector already did.
+        // Cancelled rather than Released when the caller's token went first, so the
+        // metrics distinguish an orderly hand-off from a host shutting down.
+        MarkLost(
+            _lostToken.IsCancellationRequested ? LeadershipLostReason.Cancelled : LeadershipLostReason.Released,
+            "the lease was disposed");
 
         try
         {

--- a/DLeader.Consul/Implementations/ConsulMessageBroker.cs
+++ b/DLeader.Consul/Implementations/ConsulMessageBroker.cs
@@ -16,6 +16,9 @@ namespace DLeader.Consul.Implementations;
 /// Delivery is at least once and retention is a few minutes, so this suits coordination
 /// notifications and not durable work. See the interface for the full caveats.
 /// </remarks>
+// Implementing a type this package deprecates, on purpose: the interface still ships
+// and still works until 2.0 moves it out.
+#pragma warning disable CS0618
 public class ConsulMessageBroker : IMessageBroker, IDisposable, IAsyncDisposable
 {
     private readonly IConsulClient _consulClient;
@@ -370,3 +373,4 @@ public class ConsulMessageBroker : IMessageBroker, IDisposable, IAsyncDisposable
         GC.SuppressFinalize(this);
     }
 }
+#pragma warning restore CS0618

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,188 @@
+# Migration guide
+
+## From 1.10 to 1.13
+
+Nothing was removed. Your code still compiles, and `IsLeaderAsync()` still returns what
+it always did. What changed is that the compiler now warns about it, because the pattern
+it forces cannot be made correct.
+
+### Why `IsLeaderAsync` is obsolete
+
+```csharp
+if (await _leaderElection.IsLeaderAsync())   // true, as of a moment ago
+{
+    await DoTheWork();                        // leadership may already have moved
+}
+```
+
+The `bool` describes the past. Between the check and the work, this instance's Consul
+session can expire — a garbage-collection pause longer than `SessionTTL` is enough — and
+another instance can be granted leadership. Both then run `DoTheWork()`.
+
+Checking again inside the loop does not help. A paused process cannot check anything
+while it is paused. This is not a bug in the implementation; it is what the signature
+permits.
+
+### The replacement
+
+Hold a lease for the duration of the work, and pass its fencing token to whatever you
+are protecting.
+
+```csharp
+public sealed class InvoiceWorker : BackgroundService
+{
+    private readonly ILeadershipLeaseProvider _leases;   // was ILeaderElection
+    private readonly IInvoiceStore _store;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Waits on a blocking query rather than polling.
+            await using var lease = await _leases.AcquireLeadershipAsync(stoppingToken);
+
+            using var work = CancellationTokenSource.CreateLinkedTokenSource(
+                lease.LostToken, stoppingToken);
+
+            try
+            {
+                while (!work.IsCancellationRequested)
+                {
+                    await _store.CloseBatchAsync(lease.FencingToken, work.Token);
+                    await Task.Delay(TimeSpan.FromSeconds(5), work.Token);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Leadership moved on, or the host is stopping.
+            }
+        }
+    }
+}
+```
+
+### Step by step
+
+**1. Change the injected dependency.**
+
+```diff
+- private readonly ILeaderElection _leaderElection;
++ private readonly ILeadershipLeaseProvider _leases;
+```
+
+Registration does not change: `AddConsulLeaderElection(...)` registers both interfaces
+against one shared instance.
+
+**2. Delete the `StartLeaderElectionAsync` call.** The lease API does not need it.
+Acquisition is the whole protocol.
+
+```diff
+- await _leaderElection.StartLeaderElectionAsync(stoppingToken);
+```
+
+**3. Replace the check with a lease.**
+
+```diff
+- while (!stoppingToken.IsCancellationRequested)
+- {
+-     if (await _leaderElection.IsLeaderAsync())
+-     {
+-         await DoTheWork();
+-     }
+-     await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+- }
++ while (!stoppingToken.IsCancellationRequested)
++ {
++     await using var lease = await _leases.AcquireLeadershipAsync(stoppingToken);
++
++     using var work = CancellationTokenSource.CreateLinkedTokenSource(
++         lease.LostToken, stoppingToken);
++
++     try
++     {
++         while (!work.IsCancellationRequested)
++         {
++             await DoTheWork(lease.FencingToken, work.Token);
++             await Task.Delay(TimeSpan.FromSeconds(5), work.Token);
++         }
++     }
++     catch (OperationCanceledException) { }
++ }
+```
+
+Use `TryAcquireLeadershipAsync` instead of `AcquireLeadershipAsync` when a follower has
+work of its own to do rather than idling; it returns `null` immediately instead of
+waiting.
+
+**4. Make the resource check the fencing token.** This is the step that actually buys
+you anything, and the one it is tempting to skip.
+
+```sql
+UPDATE invoice_batches
+   SET status = 'closed', fencing_token = @token
+ WHERE id = @id
+   AND fencing_token <= @token;
+```
+
+If the update affects no rows, a later leader has already been here and this instance is
+stale — whatever its lease still believes.
+
+Without this step you have an advisory lock and a race. See
+[What this does not guarantee](README.md#what-this-does-not-guarantee).
+
+**5. Replace the events, if you used them.**
+
+`OnLeadershipAcquired` and `OnLeadershipLost` still work, but they hand the handler
+nothing to fence with. The lease loop above covers both transitions: the body runs on
+acquisition, and `work.Token` cancels on loss.
+
+### Behaviour that changed in 1.11 and 1.12
+
+These are fixes, but they are observable, so check them against your assumptions:
+
+| Change | What you may notice |
+|---|---|
+| A lost session now raises `OnLeadershipLost` and rebuilds the session | Previously the node went silent and never led again. If you were restarting processes to recover from that, you can stop. |
+| Startup no longer deregisters sibling instances of the same service | Set `ServiceRegistrationOptions.DeregisterSiblingInstancesOnStart = true` to restore the old behaviour. It was destructive when two instances shared a Consul agent. |
+| `ServiceRegistrationOptions` is now honoured | Five of its six properties were silently ignored before. If you set `HealthCheckEndpoint`, `HealthCheckInterval`, `HealthCheckTimeout`, `DeregisterCriticalServiceAfter` or `Tags`, they take effect now. Check they say what you meant. |
+| The health check address falls back to the machine name, not `localhost` | If you relied on the old fallback, set `ServiceRegistrationOptions.ServiceAddress` explicitly. |
+| `GetCurrentLeaderAsync` returns empty while the lock is unheld | It used to return the last leader's id from a key nobody held. |
+| The message broker no longer replays the retention window on every message | Handlers that were tolerating duplicates will see far fewer. |
+
+### New settings worth reviewing
+
+| Setting | Default | Why you might change it |
+|---|---|---|
+| `AclToken` | *(empty)* | Required if your cluster has ACLs enabled. Without it every call is rejected. |
+| `LockDelaySeconds` | `15` | The main safety/failover dial. Lower means faster failover and a smaller window for a failed leader to notice. |
+| `LeaseSafetyMarginSeconds` | `2` | Subtracted from `SessionTTL` to get the local deadline at which a lease declares itself lost. |
+
+### Observability
+
+1.13 publishes an `ActivitySource` and a `Meter`, both named `DLeader.Consul`:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(t => t.AddSource(LeadershipTelemetry.ActivitySourceName))
+    .WithMetrics(m => m.AddMeter(LeadershipTelemetry.MeterName));
+```
+
+The instrument to alert on is `dleader.consul.leadership.lost` and its `reason` tag:
+
+- `session_expired` / `lock_key_taken` — Consul made a decision and told this node.
+- `local_deadline_exceeded` — this node could not reach Consul and stood down on its own
+  clock. **This is what a network partition looks like from inside the process**, and it
+  is the one worth paging on.
+
+`ILeadershipLease.LostReason` exposes the same value in code.
+
+---
+
+## Looking ahead to 2.0
+
+`ILeaderElection` — the whole interface, not just `IsLeaderAsync` — is going away in
+2.0, along with the Consul service registration that only it used. `IMessageBroker` is
+moving to a separate `DLeader.Consul.Messaging` package.
+
+Migrating to the lease API now means 2.0 is a version bump rather than a rewrite. Follow
+the steps above and you are already done.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ While `lease.LostToken` has not been cancelled:
 
 | Assumption | If it does not hold |
 |---|---|
-| The Consul cluster keeps a quorum. | No leases are granted. Existing leases expire at their TTL. Availability is lost; safety is not. |
+| The Consul cluster keeps a quorum. | No leases are granted, and the holder stands down on its local deadline because its renewals cannot be committed either. Availability is lost; safety is not. Covered by a test against a three-server cluster with two servers stopped. |
 | The Consul cluster is not restored from a snapshot or rebuilt. | Raft indices can move backwards, so a new leader's fencing token may be *lower* than an old one's. Guarantee 2 breaks. This is the one failure mode where fencing itself stops protecting you. |
 | Only this library writes to `service/{ServiceName}/leader`. | Anything else writing that key can move the lock or the index arbitrarily. |
 | The process is scheduled often enough to run its own watchdog. | Cancellation of `LostToken` is delayed by however long the process was frozen. See below. |
@@ -303,6 +303,35 @@ builder.Services.AddConsulLeaderElection(
 
 ---
 
+## Observability
+
+The library publishes an `ActivitySource` and a `Meter`, both named `DLeader.Consul`:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(t => t.AddSource(LeadershipTelemetry.ActivitySourceName))
+    .WithMetrics(m => m.AddMeter(LeadershipTelemetry.MeterName));
+```
+
+| Instrument | |
+|---|---|
+| `dleader.consul.leadership.lost` | Losses, tagged by `reason`. **The one to alert on.** |
+| `dleader.consul.leadership.acquisitions` | Attempts, tagged `acquired` / `contended` / `failed`. |
+| `dleader.consul.leadership.held` | 1 while this process holds a lease. Summed across a fleet it should never exceed one per service. |
+| `dleader.consul.leadership.tenure` | How long each term lasted, in seconds. |
+| `dleader.consul.session.renewals` | Renewals, tagged `ok` / `failed`. Rising failures with no loss means the margin is being eaten into. |
+| `dleader.consul.leadership.fencing_token_issued` | Tokens issued. Alert on it going backwards — see the snapshot-restore assumption above. |
+
+The `reason` tag is why this exists:
+
+- `session_expired`, `lock_key_taken` — Consul made a decision and told this node.
+- `local_deadline_exceeded` — this node could not reach Consul and stood down on its own
+  clock. **This is what a network partition looks like from inside the process.** It is
+  a different incident from the first two and deserves a different alert.
+
+`ILeadershipLease.LostReason` exposes the same value in code, for callers that want to
+react differently to a partition than to an orderly hand-off.
+
 ## The older API
 
 `ILeaderElection` — `StartLeaderElectionAsync`, `OnLeadershipAcquired`,
@@ -315,23 +344,41 @@ A single `ConsulLeaderElection` instance uses one API or the other, never both �
 contend for the same key with separate sessions, and mixing them throws
 `InvalidOperationException`.
 
+**`ILeaderElection` is removed entirely in 2.0**, along with the Consul service
+registration that only it used, and `IMessageBroker` moves to a separate
+`DLeader.Consul.Messaging` package. [MIGRATION.md](MIGRATION.md) walks through moving to
+the lease API; doing it now makes 2.0 a version bump rather than a rewrite.
+
 ---
 
 ## Development
 
 ```bash
-dotnet build                                                   # net8.0, net9.0, net10.0
-dotnet test DLeader.Consul.Tests                               # unit, all targets
-dotnet test DLeader.Consul.IntegrationTests                    # needs Docker
+dotnet build                                                    # net8.0, net9.0, net10.0
+dotnet test DLeader.Consul.Tests                                # unit, all targets
+dotnet test DLeader.Consul.IntegrationTests \
+  --filter "Category!=Cluster"                                  # needs Docker
+dotnet test DLeader.Consul.IntegrationTests \
+  --filter "Category=Cluster" -f net8.0                         # 3-server cluster, slow
 ```
 
-Integration tests start a real Consul in a container through Testcontainers, run on all
-three targets, and cover contested acquisition, fencing-token monotonicity, loss
-detection when the session is destroyed, loss detection when the agent becomes
-unreachable, message delivery and de-duplication, and what the campaign path actually
-registers. They are the only tests that can tell you whether the guarantees above hold —
-every bug fixed in 1.11.0 was invisible to the mocked suite — so changes to the lease or
-broker paths need to go through them.
+Integration tests start real Consul containers through Testcontainers. They are the only
+tests that can tell you whether the guarantees above hold — every bug fixed in 1.11.0 was
+invisible to the mocked suite, and two more were found by these — so changes to the lease
+or broker paths need to go through them.
+
+Most run against a single agent and cover contested acquisition, fencing-token
+monotonicity, loss detection when the session is destroyed, loss detection when the agent
+becomes unreachable, ACL enforcement, message delivery and de-duplication, and what the
+campaign path registers.
+
+The `Cluster` category runs against **three Consul servers with real Raft**, and covers
+quorum loss, Raft leader failover, and fencing-token monotonicity across a Consul
+election. Those are the only tests that exercise what makes Consul strongly consistent —
+a single dev agent has no quorum to lose — so they are what backs the assumptions table
+above. They are slow by design: bootstrapping Raft and waiting out an election takes real
+time and cannot be faked. CI runs them once rather than per target framework, since
+nothing they test varies by framework.
 
 Requires the .NET 10 SDK to build (it produces all three targets) and Docker to run the
 integration suite.


### PR DESCRIPTION
Three things this library could not answer before.

## Why did leadership move

An `ActivitySource` and a `Meter`, both named `DLeader.Consul`. No new dependency — both live in the shared framework from net8.0 on, which I verified rather than assumed.

The instrument that matters is `dleader.consul.leadership.lost` and its `reason` tag:

| reason | meaning |
|---|---|
| `session_expired`, `lock_key_taken` | Consul made a decision and told this node |
| `local_deadline_exceeded` | this node could not reach Consul and stood down on its own clock — **what a partition looks like from inside the process** |

Those are different incidents deserving different alerts, and until now they were distinguishable only by reading log prose. `ILeadershipLease.LostReason` exposes the same value in code, added as a default interface member so nothing existing stops compiling.

The tests assert the reason is *correct*, not just that a metric fired. A test that only counted losses would pass with the two reasons swapped — worse than no test, because it would make a wrong dashboard look verified.

## How to get off `IsLeaderAsync`

[MIGRATION.md](MIGRATION.md), shipped inside the package so the upgrade path travels with the thing being upgraded. Covers the diff step by step, the step people skip (making the resource compare the fencing token), and the behaviour changes from 1.11/1.12 worth checking against existing assumptions.

## Whether the guarantees hold

Every test until now ran against `consul agent -dev`: one node, no quorum, nothing to lose. The README claims the leadership guarantees are Consul's, inherited — **that claim was untested**.

Four tests now run against three servers with real Raft: quorum loss, Raft leader failover, fencing-token monotonicity across a Consul election, and recovery. The assumptions table in the README now cites them instead of asserting.

### One finding worth reading

That failover test had a synchronisation bug of its own. It **passed in isolation and failed in the full suite**: after stopping the Raft leader, the survivors keep reporting the dead node's address until the election completes, so waiting for a non-empty `/v1/status/leader` hands back the node just killed. Waiting for a leader that is *not* the one we stopped is the condition that actually means failover happened.

Committing after the isolated 4/4 would have shipped an intermittent CI flake. It was a test bug, not a library bug.

## Also

- `IMessageBroker` is `[Obsolete]`, announcing its move to `DLeader.Consul.Messaging` in 2.0. The deprecation propagates into the tests and sample, which is the point; those sites are marked deliberate rather than silenced project-wide.
- CI runs the cluster tests once rather than per target framework — nothing they exercise varies by framework, and running them three times would triple the slowest step for no signal.

## Testing

- 46 unit × 3 targets
- 35 integration on net8.0, including the 4 cluster tests

2.0 scope is now decided and recorded on #4.